### PR TITLE
Функциональность «Общие фильмы» (повторно)

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -60,6 +60,18 @@ public class FilmController {
         return filmService.findTopLiked(count, genreId, year);
     }
 
+    /**
+     * Возвращает список общих с другом фильмов, отсортированных по популярности.
+     *
+     * @param userId   идентификатор пользователя, запрашивающего информацию
+     * @param friendId идентификатор пользователя, с которым сравниваем список фильмов
+     */
+    @GetMapping("/common")
+    public List<Film> findCommonFilms(@RequestParam Integer userId,
+                                      @RequestParam Integer friendId) {
+        return filmService.findCommonFilms(userId, friendId);
+    }
+
     @PostMapping
     public Film create(@Valid @NotNull @RequestBody FilmCreateDto filmCreateDto) {
         return filmService.create(filmCreateDto);

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -72,6 +72,12 @@ public class FilmService {
         return List.of();
     }
 
+    public List<Film> findCommonFilms(Integer userId, Integer friendId) {
+        validators.validateUserExits(userId, getClass());
+        validators.validateUserExits(friendId, getClass());
+        return filmStorage.findCommonFilms(userId, friendId);
+    }
+
     public Film create(FilmCreateDto filmCreateDto) {
         Film film = filmMapper.toEntity(filmCreateDto);
         return filmStorage.create(film);

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -217,6 +217,21 @@ public class FilmDbStorage implements FilmStorage {
         return jdbcTemplate.query(query, mapper, directorId);
     }
 
+    @Override
+    public List<Film> findCommonFilms(Integer userId, Integer friendId) {
+        String query = """
+                SELECT f.*
+                FROM film f
+                JOIN "like" l_user ON f.id = l_user.film_id AND l_user.user_id = ?
+                JOIN "like" l_friend ON f.id = l_friend.film_id AND l_friend.user_id = ?
+                LEFT JOIN "like" l_all ON f.id = l_all.film_id
+                GROUP BY f.id, f.name, f.description, f.release_date, f.duration, f.mpa_id
+                ORDER BY COUNT(l_all.user_id) DESC, f.id;
+                """;
+
+        return jdbcTemplate.query(query, mapper, userId, friendId);
+    }
+
     private Set<Integer> extractGenreIdSet(Film film) {
         return film.getGenres().stream()
                 .mapToInt(Genre::getId)

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -28,4 +28,14 @@ public interface FilmStorage {
     List<Film> findTopLiked(int count, Integer genreId, Integer year);
 
     List<Film> findByDirector(Integer directorId, SortOrder order);
+
+    /**
+     * Находит фильмы, которые лайкнули оба пользователя, отсортированные
+     * по популярности (общему количеству лайков).
+     *
+     * @param userId   идентификатор пользователя
+     * @param friendId идентификатор друга
+     * @return список общих фильмов
+     */
+    List<Film> findCommonFilms(Integer userId, Integer friendId);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
@@ -80,4 +80,12 @@ public class InMemoryFilmStorage extends AbstractInMemoryStorage<Film> implement
     public List<Film> findByDirector(Integer directorId, SortOrder order) {
         return List.of();
     }
+
+    @Override
+    public List<Film> findCommonFilms(Integer userId, Integer friendId) {
+        return mapEntityStorage.values().stream()
+                .filter(film -> film.getLikes().contains(userId) && film.getLikes().contains(friendId))
+                .sorted(Comparator.<Film, Integer>comparing(film -> film.getLikes().size()).reversed())
+                .toList();
+    }
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/service/FilmServiceTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/service/FilmServiceTest.java
@@ -320,4 +320,74 @@ class FilmServiceTest {
         // Проверяем, что возвращается пустой список
         assertThat(films2022).isEmpty();
     }
+
+    /**
+     * Тест метода findCommonFilms:
+     * должны возвращаться только общие для двух пользователей фильмы,
+     * отсортированные по популярности (количеству лайков).
+     */
+    @Test
+    void findCommonFilms_shouldReturnIntersectionSortedByPopularity() {
+        Integer userId = testUsers.get(0).getId();   // первый пользователь
+        Integer friendId = testUsers.get(1).getId(); // второй пользователь
+
+        List<Film> commonFilms = filmService.findCommonFilms(userId, friendId);
+
+        // Пользователи 1 и 2 ставят лайки фильмам с likesCount >= 2,
+        // т.е. общие для них фильмы: dramaFilm2020 (4 лайка),
+        // comedyFilm2020 (3 лайка), dramaFilm2021 (2 лайка).
+        assertThat(commonFilms)
+                .extracting(Film::getId)
+                .containsExactly(
+                        dramaFilm2020.getId(),
+                        comedyFilm2020.getId(),
+                        dramaFilm2021.getId()
+                );
+    }
+
+    /**
+     * Тест метода findCommonFilms с несуществующим пользователем:
+     * ожидаем NotFoundException от валидатора.
+     */
+    @Test
+    void findCommonFilms_withNonExistentUser_shouldThrowNotFound() {
+        Integer existingUserId = testUsers.get(0).getId();
+        Integer nonExistentUserId = 9999;
+
+        assertThatThrownBy(() -> filmService.findCommonFilms(nonExistentUserId, existingUserId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Пользователь id=" + nonExistentUserId + " не найден");
+    }
+
+    /**
+     * Тест метода findCommonFilms:
+     * оба пользователя существуют, но у одного из них нет лайков,
+     * поэтому общие фильмы отсутствуют и должен вернуться пустой список.
+     *
+     * В setUp() у нас 5 пользователей, лайки раздаются только первым четырём,
+     * пятый пользователь (testUsers.get(4)) не ставит лайков ни одному фильму.
+     */
+    @Test
+    void findCommonFilms_whenUsersHaveNoCommonLikes_shouldReturnEmptyList() {
+        Integer userIdWithLikes = testUsers.get(0).getId();   // ставил лайки
+        Integer userIdWithoutLikes = testUsers.get(4).getId(); // не ставил лайков
+
+        List<Film> commonFilms = filmService.findCommonFilms(userIdWithLikes, userIdWithoutLikes);
+
+        assertThat(commonFilms).isEmpty();
+    }
+
+    /**
+     * Тест метода findCommonFilms с несуществующим другом:
+     * ожидаем NotFoundException от валидатора для friendId.
+     */
+    @Test
+    void findCommonFilms_withNonExistentFriend_shouldThrowNotFound() {
+        Integer existingUserId = testUsers.get(0).getId();
+        Integer nonExistentFriendId = 9999;
+
+        assertThatThrownBy(() -> filmService.findCommonFilms(existingUserId, nonExistentFriendId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Пользователь id=" + nonExistentFriendId + " не найден");
+    }
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/FilmStorageTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/FilmStorageTest.java
@@ -151,4 +151,31 @@ public class FilmStorageTest {
         List<Film> films = storage.findTopLiked(3);
         assertThat(films).extracting(Film::getId).containsExactly(3, 1, 2);
     }
+
+    @Test
+    public void testFindCommonFilms_shouldReturnIntersectionSortedByPopularity() {
+        // Иван (id=1) и Мария (id=2) совместно лайкнули фильмы 1 и 3.
+        // По данным data.sql: у фильма 3 три лайка, у фильма 1 — два,
+        // поэтому порядок по популярности должен быть [3, 1].
+        List<Film> films = storage.findCommonFilms(1, 2);
+
+        assertThat(films)
+                .extracting(Film::getId)
+                .containsExactly(3, 1);
+    }
+
+    /**
+     * Тест метода findCommonFilms:
+     * при отсутствии общих лайков должен возвращаться пустой список.
+     *
+     * Здесь второй пользователь (id=999) не имеет ни одной записи в таблице "like",
+     * поэтому пересечение лайкнутых фильмов пользователя 1 и пользователя 999 пустое.
+     * Проверка существования пользователя лежит на сервисном слое, а не на хранилище.
+     */
+    @Test
+    public void testFindCommonFilms_whenNoCommonLikes_shouldReturnEmptyList() {
+        List<Film> films = storage.findCommonFilms(1, 999);
+
+        assertThat(films).isEmpty();
+    }
 }


### PR DESCRIPTION
Добавлен функционал «Общие фильмы».

Реализован новый эндпоинт GET /films/common, возвращающий список фильмов, которые лайкнули оба пользователя.
Результат сортируется по популярности (количеству лайков).

Добавлена поддержка операции на всех уровнях приложения: контроллер, сервисный слой, интерфейс хранилища и реализации FilmDbStorage и InMemoryFilmStorage.
SQL-запрос оптимизирован для выборки пересечения списков лайков с одновремённым подсчётом общей популярности.

Выполнена базовая валидация: оба пользователя должны существовать.